### PR TITLE
Add caniuse.rs integration

### DIFF
--- a/extension/index/caniuse.js
+++ b/extension/index/caniuse.js
@@ -1,0 +1,1 @@
+var caniuseIndex = [["1.46", "const_loop", "`loop` and `while` in constant evaluation", 2344], ["1.4", "use_group_renaming", "item renamings in import groups", null]];

--- a/extension/main.js
+++ b/extension/main.js
@@ -1,6 +1,7 @@
 const c = new Compat();
 const crateSearcher = new CrateSearch(mapping, crateIndex);
 const attributeSearcher = new AttributeSearch(attributesIndex);
+const caniuseSearcher = new CaniuseSearch(caniuseIndex);
 const bookSearcher = new BookSearch(booksIndex);
 const lintSearcher = new LintSearch(lintsIndex);
 const crateDocSearchManager = new CrateDocSearchManager();
@@ -182,6 +183,29 @@ omnibox.addPrefixQueryEvent("#", {
             description: `Attribute: ${c.match("#[" + attribute.name + "]")} ${c.dim(attribute.description)}`,
         }
     }
+});
+
+omnibox.addPrefixQueryEvent("?", {
+    defaultSearch: true,
+    searchPriority: 3,
+    onSearch: (query) => {
+        return caniuseSearcher.search(query);
+    },
+    onFormat: (index, feat, query) => {
+        let content;
+        let description;
+        if (query.startsWith("??")) {
+            content = `https://github.com/rust-lang/rfcs/pull/${feat.rfc}`;
+            description = `RFC: ${c.match(feat.flag)} - ${feat.title}`
+        } else {
+            content = `https://caniuse.rs/features/${feat.flag}`;
+            description = `${c.capitalize("caniuse.rs")}: ${c.match(feat.flag)} - ${feat.title} - since ${feat.ver}`
+        }
+        return {
+            content,
+            description
+        };
+    },
 });
 
 omnibox.addRegexQueryEvent(/`?e\d{2,4}`?$/i, {

--- a/extension/main.js
+++ b/extension/main.js
@@ -186,8 +186,6 @@ omnibox.addPrefixQueryEvent("#", {
 });
 
 omnibox.addPrefixQueryEvent("?", {
-    defaultSearch: true,
-    searchPriority: 3,
     onSearch: (query) => {
         return caniuseSearcher.search(query);
     },

--- a/extension/search/caniuse.js
+++ b/extension/search/caniuse.js
@@ -1,0 +1,34 @@
+function CaniuseSearch(index) {
+  this.feats = {};
+  index.forEach(([ver, flag, title, rfc]) => {
+    let searchTerm = `${flag}: ${title}`.replace(/[-_\s#\?]/ig, "");
+    this.feats[searchTerm] = { ver, flag, title, rfc };
+  });
+  this.searchTerms = Object.keys(this.feats);
+}
+
+CaniuseSearch.prototype.search = function (rawKeyword) {
+  let keyword = rawKeyword.replace(/[-_\s#\?]/ig, "");
+  let result = [];
+
+  for (let searchTerm of this.searchTerms) {
+    if (searchTerm.length < keyword.length) continue;
+
+    let foundAt = searchTerm.indexOf(keyword);
+    if (foundAt > -1) {
+      let rfc = this.feats[searchTerm].rfc;
+      // skip those without RFC when searching for RFCs
+      if (!(rawKeyword.startsWith("??") && rfc == null)) {
+        result.push({
+          ver: this.feats[searchTerm].ver,
+          flag: this.feats[searchTerm].flag,
+          title: this.feats[searchTerm].title,
+          rfc,
+          matchIndex: foundAt,
+        });
+      }
+    }
+  }
+
+  return result;
+};

--- a/manifest.jsonnet
+++ b/manifest.jsonnet
@@ -17,9 +17,9 @@ local json = manifest.new(
              .addBackgroundScripts(
   ['settings.js', 'deminifier.js']
 )
-             .addBackgroundScripts(utils.js_files('search', ['book', 'crate', 'attribute', 'lint']))
+             .addBackgroundScripts(utils.js_files('search', ['book', 'crate', 'attribute', 'caniuse', 'lint']))
              .addBackgroundScripts(utils.js_files('search/docs', ['base', 'std', 'crate-doc']))
-             .addBackgroundScripts(utils.js_files('index', ['attributes', 'books', 'crates', 'std-docs', 'lints', 'labels', 'commands']))
+             .addBackgroundScripts(utils.js_files('index', ['attributes', 'books', 'caniuse', 'crates', 'std-docs', 'lints', 'labels', 'commands']))
              .addBackgroundScripts(utils.js_files('command', ['label', 'help', 'stable', 'stats']))
              .addBackgroundScripts('main.js')
              .addContentScript(


### PR DESCRIPTION
First of all I want to say a huge thank you for this extension, it has very much integrated to my workflow when working with Rust (sadly not much if any at work yet). While scanning the issues I'm particularly interested in #22 and this is my attempt at it.

It took me a while to figure out how the data is imported, and my plan is to have a Rust binary to load the data from a local path. As I understand caniuse.rs does not provide "API" to fetch all data so the most reliable way I can think of is to import data directly from their repo. This can be easily integrated into the build pipeline as well, I believe, as we'll only need to add an additional `git clone` before running the Rust binary. Another option is to include it as a submodule, but I'm not sure that makes sense for this project.

I included a small sample of index data and I would like to know if you have any feedback on the layout and the above approach regarding fetching the data (before I further commit to implement them). (And of course on everything else, I'm beginner at JS without much intent to be proficient with it 😄 )

It currently works like this:

![image](https://user-images.githubusercontent.com/222272/94974634-ab797480-04fe-11eb-9f08-ad471a1db38f.png)

![image](https://user-images.githubusercontent.com/222272/94974640-b0d6bf00-04fe-11eb-901f-adb1ad2e85ed.png)

The first will redirect to caniuse.rs and the latter will redirect to the RFC (it also excludes those without RFCs)