### PR TITLE
faq: use private address in example

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -38,8 +38,8 @@ Sure. A good choice is use http server! For example using python **http.server**
 
 ```sh
 $ cd your-rust-doc-directory
-$ python -m http.server
-Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
+$ python3 -m http.server --bind 127.0.0.1
+Serving HTTP on 127.0.0.1 port 8000 (http://127.0.0.1:8000/) ...
 ```
 
-Then set `http://0.0.0.0:8000` as your local doc path.
+Then set `http://127.0.0.1:8000` as your local doc path.


### PR DESCRIPTION
Use private loopback address 127.0.0.1 instead of 0.0.0.0, which listens
on all interfaces. Listening on all interfaces is a potential security
hazard and not necessary to serve a private/local site.

Offical docs on https://docs.python.org/3/library/http.server.html say:

> Warning: http.server is not recommended for production. It only
> implements basic security checks.

Also changes example to use `python3` instead of `python` executable. On
many systems, `python` refers to `python2`, which is EOL and does not
have the `http.server` module.