### PR TITLE
Migrate localStorage to chrome storage API

### DIFF
--- a/extension/crate-manager.js
+++ b/extension/crate-manager.js
@@ -1,31 +1,31 @@
 class CrateDocManager {
-    static getCrates() {
-        return JSON.parse(localStorage.getItem("crates") || "{}");
+    static async getCrates() {
+        return await storage.getItem("crates") || {};
     }
 
     static getCrateSearchIndex(name) {
-        return JSON.parse(localStorage.getItem(`@${name}`));
+        return storage.getItem(`@${name}`);
     }
 
     static addCrate(name, version, searchIndex) {
         if (searchIndex.hasOwnProperty(name)) {
-            localStorage.setItem(`@${name}`, JSON.stringify(searchIndex));
+            storage.setItem(`@${name}`, searchIndex);
             let doc = searchIndex[name]["doc"];
             let crates = CrateDocManager.getCrates();
             if (name in crates) {
                 // Don't override the time if the crate exists
-                crates[name] = {version, doc, time: crates[name].time};
+                crates[name] = { version, doc, time: crates[name].time };
             } else {
-                crates[name] = {version, doc, time: Date.now()};
+                crates[name] = { version, doc, time: Date.now() };
             }
-            localStorage.setItem("crates", JSON.stringify(crates));
+            storage.setItem("crates", crates);
         }
     }
 
     static removeCrate(name) {
         let crates = CrateDocManager.getCrates();
         delete crates[name];
-        localStorage.setItem("crates", JSON.stringify(crates));
-        localStorage.removeItem(`@${name}`);
+        storage.setItem("crates", crates);
+        storage.removeItem(`@${name}`);
     }
 }

--- a/extension/main.js
+++ b/extension/main.js
@@ -413,9 +413,6 @@ function getPlatformOs() {
         if (changes.crateRegistry) {
             crateRegistry = changes.crateRegistry.newValue;
         }
-        if (changes.crateRegistry) {
-            crateRegistry = changes.crateRegistry.newValue;
-        }
     });
 
     if (await settings.autoUpdate) {
@@ -428,7 +425,7 @@ function getPlatformOs() {
         }
 
         Omnibox.navigateToUrl(INDEX_UPDATE_URL);
-        storage.setItem('auto-update-version', `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`);
+        await storage.setItem('auto-update-version', `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`);
     }
 
     chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -554,7 +551,7 @@ function getPlatformOs() {
         return true;
     });
 
-    // Put blog release request last to avoid reload error due to
+    // Put blog release request last to avoid error due to
     // possibly request failed. E.g. Github Pages down.
     let response = await fetch("https://blog.rust-lang.org/releases.json");
     commandManager.addCommand(new BlogCommand((await response.json())["releases"]));

--- a/extension/migration.js
+++ b/extension/migration.js
@@ -1,9 +1,8 @@
-// Migrate data from locaStorage to chrome.storage API.
-//
-// This migrations is required because Chrome Manifest V3 change background script to service worker,
-// however, service worker doesn't support localStorage API. Therefore, we should migrate those data to
-// chrome.storage before we upgrade to Manifest V3. Otherwise, we cann't do such a migrations, because we
-// cannot access to localStorage API in service worker any more.
+// This migration is required because Chrome Manifest V3 changes the background script
+// to the service worker, however, the service worker doesn't support localStorage API.
+// Therefore, we should migrate those data to chrome.storage before we upgrade to Manifest V3.
+// Otherwise, we can't do such a migration, because we cannot access localStorage API
+// in the service worker anymore.
 async function migrate() {
     // If localStorage API unavailable means we are in Manifest V3,
     // we cannot do this migrations.
@@ -31,6 +30,6 @@ async function migrate() {
         await migrateLocalStorage(`@${crate}`);
     }
 
-    storage.setItem('migrate-result', true);
+    await storage.setItem('migrate-result', true);
     console.log('migrate finised');
 }

--- a/extension/migration.js
+++ b/extension/migration.js
@@ -12,6 +12,12 @@ async function migrate() {
         return;
     }
 
+    // Don't re-migrate.
+    if (await storage.getItem('migrate-result')) {
+        console.log('Already migrated.');
+        return;
+    }
+
     console.log('starting migration...');
     // Migrate all keys.
     const keys = ['history', 'statistics', 'crates', 'auto-update', 'auto-update-version', 'offline-mode', 'offline-path', 'crate-registry', 'default-search'];
@@ -24,5 +30,7 @@ async function migrate() {
     for (let crate in crates) {
         await migrateLocalStorage(`@${crate}`);
     }
+
+    storage.setItem('migrate-result', true);
     console.log('migrate finised');
 }

--- a/extension/migration.js
+++ b/extension/migration.js
@@ -1,0 +1,28 @@
+// Migrate data from locaStorage to chrome.storage API.
+//
+// This migrations is required because Chrome Manifest V3 change background script to service worker,
+// however, service worker doesn't support localStorage API. Therefore, we should migrate those data to
+// chrome.storage before we upgrade to Manifest V3. Otherwise, we cann't do such a migrations, because we
+// cannot access to localStorage API in service worker any more.
+async function migrate() {
+    // If localStorage API unavailable means we are in Manifest V3,
+    // we cannot do this migrations.
+    if (!localStorage) {
+        console.error('localStorage doesn\'t support');
+        return;
+    }
+
+    console.log('starting migration...');
+    // Migrate all keys.
+    const keys = ['history', 'statistics', 'crates', 'auto-update', 'auto-update-version', 'offline-mode', 'offline-path', 'crate-registry', 'default-search'];
+    for (let key of keys) {
+        await migrateLocalStorage(key);
+    }
+
+    // Migrate all search index of crates.
+    let crates = JSON.parse(localStorage.getItem('crates') || '{}');
+    for (let crate in crates) {
+        await migrateLocalStorage(`@${crate}`);
+    }
+    console.log('migrate finised');
+}

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,32 +1,46 @@
 const settings = {
     get autoUpdate() {
-        return JSON.parse(localStorage.getItem('auto-update')) || false;
+        return (async () => {
+            return await storage.getItem('auto-update') || false;
+        })();
     },
     set autoUpdate(mode) {
-        localStorage.setItem('auto-update', mode);
+        storage.setItem('auto-update', mode);
     },
     get isOfflineMode() {
-        return JSON.parse(localStorage.getItem('offline-mode')) || false;
+        return (async () => {
+            return await storage.getItem('offline-mode') || false;
+        })();
     },
     set isOfflineMode(mode) {
-        localStorage.setItem('offline-mode', mode);
+        storage.setItem('offline-mode', mode);
     },
     get offlineDocPath() {
-        return localStorage.getItem('offline-path');
+        return (async () => {
+            return await storage.getItem('offline-path');
+        })();
     },
     set offlineDocPath(path) {
-        localStorage.setItem('offline-path', path);
+        storage.setItem('offline-path', path);
     },
     get crateRegistry() {
-        return localStorage.getItem("crate-registry") || "crates.io";
+        return (async () => {
+            return await storage.getItem("crate-registry") || "crates.io";
+        })();
     },
     set crateRegistry(value) {
-        localStorage.setItem("crate-registry", value);
+        storage.setItem("crate-registry", value);
     },
     get defaultSearch() {
-        return JSON.parse(localStorage.getItem("default-search")) || { thirdPartyDocs: false, docsRs: true, attributes: true };
+        return (async () => {
+            return await storage.getItem("default-search") || {
+                thirdPartyDocs: false,
+                docsRs: true,
+                attributes: true
+            };
+        })();
     },
     set defaultSearch(value) {
-        localStorage.setItem("default-search", JSON.stringify(value));
+        storage.setItem("default-search", value);
     }
 };

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,3 +1,5 @@
+// All getters are async getter, all setter are sync setter,
+// we just ignore the set promise.
 const settings = {
     get autoUpdate() {
         return (async () => {

--- a/extension/statistics.js
+++ b/extension/statistics.js
@@ -105,7 +105,7 @@ class Statistics {
      * @param the search history item
      * @param autoSave whether auto save the statistics result into local storage
      */
-    record({ query, content, description, time }, autoSave = false) {
+    async record({ query, content, description, time }, autoSave = false) {
         let date = new Date(time);
         this.hoursData[date.getHours()] += 1;
 
@@ -126,7 +126,7 @@ class Statistics {
         this.total += 1;
 
         if (autoSave) {
-            this.save();
+            await this.save();
         }
     }
 

--- a/manage/templates/base.html
+++ b/manage/templates/base.html
@@ -39,6 +39,9 @@
             </div>
         </div>
     </div>
+    <script src="../core/compat.js"></script>
+    <script src="../core/storage.js"></script>
+    <script src="../settings.js"></script>
     {% block js %}
     {% endblock %}
 </body>

--- a/manage/templates/crates.html
+++ b/manage/templates/crates.html
@@ -16,7 +16,6 @@
 {% endblock %} 
 
 {% block js %}
-<script src="../core/compat.js"></script>
 <script src="../crate-manager.js"></script>
 <script src="../statistics.js"></script>
 <script src="./js/crates.js"></script>

--- a/manage/templates/export.html
+++ b/manage/templates/export.html
@@ -45,8 +45,6 @@
 {% endblock %}
 
 {% block js %}
-<script src="../core/compat.js"></script>
-<script src="../settings.js"></script>
 <script src="../crate-manager.js"></script>
 <script src="../statistics.js"></script>
 <script src="./js/export.js"></script>

--- a/manage/templates/index.html
+++ b/manage/templates/index.html
@@ -56,7 +56,6 @@
 
 {% block js %}
 <script type="text/javascript" src="./js/bar-chart.js"></script>
-<script type="text/javascript" src="../core/compat.js"></script>
 <script type="text/javascript" src="../statistics.js"></script>
 <script type="text/javascript" src="./js/index.js"></script>
 {% endblock %}

--- a/manage/templates/js/crates.js
+++ b/manage/templates/js/crates.js
@@ -32,7 +32,7 @@ function buildCrateItem(crate) {
     return li;
 }
 
-function refresh(orderBy = "time") {
+async function refresh(orderBy = "time") {
     let root = document.querySelector(".crate-list");
     // Clear old crate list.
     while (root.firstChild) {
@@ -40,8 +40,8 @@ function refresh(orderBy = "time") {
     }
 
     let compat = new Compat();
-    let cratesData = new Statistics().cratesData;
-    let crates = Object.entries(CrateDocManager.getCrates()).map(([name, crate]) => {
+    let cratesData = (await Statistics.load()).cratesData;
+    let crates = Object.entries(await CrateDocManager.getCrates()).map(([name, crate]) => {
         return {
             name,
             searchs: cratesData[name] || 0,
@@ -66,8 +66,10 @@ function refresh(orderBy = "time") {
 }
 
 let crateFilter = document.querySelector("select[name='crate-filter']");
-crateFilter.onchange = function () {
-    refresh(crateFilter.value);
+crateFilter.onchange = async function() {
+    await refresh(crateFilter.value);
 };
 
-refresh();
+(async() => {
+    await refresh();
+})();

--- a/manage/templates/js/export.js
+++ b/manage/templates/js/export.js
@@ -1,17 +1,17 @@
-(function () {
-    document.querySelector(".btn-export").onclick = (event) => {
+(async function() {
+    document.querySelector(".btn-export").onclick = async (event) => {
         let target = event.target.parentElement;
         let data = {};
         if (target.querySelector(".settings").checked) {
             data["settings"] = {
-                "auto-update": settings.autoUpdate,
-                "crate-registry": settings.crateRegistry,
-                "offline-mode": settings.isOfflineMode,
-                "offline-path": settings.offlineDocPath,
+                "auto-update": await settings.autoUpdate,
+                "crate-registry": await settings.crateRegistry,
+                "offline-mode": await settings.isOfflineMode,
+                "offline-path": await settings.offlineDocPath,
             };
         }
         if (target.querySelector(".search-history").checked) {
-            data["history"] = JSON.parse(localStorage.getItem("history")) || [];
+            data["history"] = storage.getItem("history") || [];
         }
         if (target.querySelector(".search-statistics").checked) {
             data["stats"] = new Statistics();
@@ -33,7 +33,7 @@
 
     function saveToFile(content, fileName, contentType) {
         let a = document.createElement("a");
-        let file = new Blob([content], {type: contentType});
+        let file = new Blob([content], { type: contentType });
         a.href = URL.createObjectURL(file);
         a.download = fileName;
         a.click();

--- a/manage/templates/js/import.js
+++ b/manage/templates/js/import.js
@@ -12,7 +12,7 @@
         fileReader.readAsText(this.files[0]);
     };
 
-    document.querySelector(".btn-import").onclick = (event) => {
+    document.querySelector(".btn-import").onclick = async (event) => {
         if (!json) {
             fileSelector.classList.add("required");
             return;
@@ -40,19 +40,19 @@
             settings.offlineDocPath = importedSettings["offline-path"];
         }
         if (json["history"] && target.querySelector(".search-history").checked) {
-            localStorage.setItem("history", JSON.stringify(json["history"]));
+            await storage.setItem("history", json["history"]);
         }
         if (json["stats"] && target.querySelector(".search-statistics").checked) {
-            localStorage.setItem("statistics", JSON.stringify(json["stats"]));
+            await storage.setItem("statistics", json["stats"]);
         }
         if (json["crates"] && target.querySelector(".crates").checked) {
             let importedCrates = json["crates"];
             let catalog = CrateDocManager.getCrates();
             for (let [name, searchIndex] of Object.entries(importedCrates["list"])) {
-                localStorage.setItem(name, JSON.stringify(searchIndex));
+                await storage.setItem(name, searchIndex);
             }
             let crates = Object.assign(catalog, importedCrates["catalog"]);
-            localStorage.setItem("crates", JSON.stringify(crates));
+            await storage.setItem("crates", crates);
         }
 
         alert("Import success!")

--- a/manage/templates/js/index.js
+++ b/manage/templates/js/index.js
@@ -35,136 +35,138 @@ const STATS_MAP = {
     }
 };
 
-const stats = new Statistics();
-const [weeksData, datesData, hoursData] = [stats.weeksData, stats.datesData, stats.hoursData]
-.map(data => {
-    return Object.entries(data).map(([key, value]) => {
-        return { name: key, value }
+(async() => {
+    const stats = await Statistics.load();
+    const [weeksData, datesData, hoursData] = [stats.weeksData, stats.datesData, stats.hoursData]
+    .map(data => {
+        return Object.entries(data).map(([key, value]) => {
+            return { name: key, value }
+        });
     });
-});
-const topCratesData = Object.entries(stats.cratesData)
-    .sort((a, b) => b[1] - a[1])
-    .map(([key, value], index) => {
-        return {
-            label: `#${index + 1}`,
-            name: key,
-            value
-        };
+    const topCratesData = Object.entries(stats.cratesData)
+        .sort((a, b) => b[1] - a[1])
+        .map(([key, value], index) => {
+            return {
+                label: `#${index + 1}`,
+                name: key,
+                value
+            };
+        });
+    topCratesData.splice(15);
+    const total = stats.total;
+
+    let heatmap = calendarHeatmap()
+        .data(stats.calendarData)
+        .selector('.chart-heatmap')
+        .tooltipEnabled(true)
+        .colorRange([
+            { min: 0, color: '#f4f7f7' },
+            { min: 1, max: 2, color: '#ffdd2b' },
+            { min: 3, max: 6, color: '#f6a405' },
+            { min: 7, max: 11, color: '#f56b04' },
+            { min: 12, max: 'Infinity', color: '#f40703' }
+        ])
+        .tooltipUnit([
+            { min: 0, unit: 'search' },
+            { min: 1, max: 1, unit: 'searches' },
+            { min: 2, max: 'Infinity', unit: 'searches' }
+        ])
+        .legendEnabled(true)
+        .onClick(function(data) {
+            console.log('data', data);
+        });
+    heatmap();
+
+    let histogramConfig = {
+        width: 460,
+        height: 240,
+        color: CHART_COLOR,
+        margin: { top: 30, right: 0, bottom: 40, left: 40 }
+    };
+    histogram({
+        selector: ".chart-histogram-week",
+        data: weeksData,
+        ...histogramConfig,
     });
-topCratesData.splice(15);
-const total = stats.total;
 
-let heatmap = calendarHeatmap()
-    .data(stats.calendarData)
-    .selector('.chart-heatmap')
-    .tooltipEnabled(true)
-    .colorRange([
-        { min: 0, color: '#f4f7f7' },
-        { min: 1, max: 2, color: '#ffdd2b' },
-        { min: 3, max: 6, color: '#f6a405' },
-        { min: 7, max: 11, color: '#f56b04' },
-        { min: 12, max: 'Infinity', color: '#f40703' }
-    ])
-    .tooltipUnit([
-        { min: 0, unit: 'search' },
-        { min: 1, max: 1, unit: 'searches' },
-        { min: 2, max: 'Infinity', unit: 'searches' }
-    ])
-    .legendEnabled(true)
-    .onClick(function(data) {
-        console.log('data', data);
+    histogram({
+        selector: ".chart-histogram-date",
+        data: datesData,
+        ...histogramConfig,
     });
-heatmap();
 
-let histogramConfig = {
-    width: 460,
-    height: 240,
-    color: CHART_COLOR,
-    margin: { top: 30, right: 0, bottom: 40, left: 40 }
-};
-histogram({
-    selector: ".chart-histogram-week",
-    data: weeksData,
-    ...histogramConfig,
-});
+    histogram({
+        selector: ".chart-histogram-hour",
+        data: hoursData,
+        ...histogramConfig,
+    });
 
-histogram({
-    selector: ".chart-histogram-date",
-    data: datesData,
-    ...histogramConfig,
-});
+    let searchTimes = document.querySelector(".search-time");
+    let frequency = searchTimes.querySelectorAll("b");
+    frequency[0].textContent = `${total}`;
+    frequency[1].textContent = calculateSavedTime(total);
 
-histogram({
-    selector: ".chart-histogram-hour",
-    data: hoursData,
-    ...histogramConfig,
-});
-
-let searchTimes = document.querySelector(".search-time");
-let frequency = searchTimes.querySelectorAll("b");
-frequency[0].textContent = `${total}`;
-frequency[1].textContent = calculateSavedTime(total);
-
-function calculateSavedTime(times) {
-    let seconds = times * 5;
-    if (seconds > 3600) {
-        let hours = seconds / 3600;
-        let minutes = seconds % 3600 / 60;
-        if (minutes > 0) {
-            return `${Math.round(hours)} hours ${Math.round(minutes)} minutes`;
+    function calculateSavedTime(times) {
+        let seconds = times * 5;
+        if (seconds > 3600) {
+            let hours = seconds / 3600;
+            let minutes = seconds % 3600 / 60;
+            if (minutes > 0) {
+                return `${Math.round(hours)} hours ${Math.round(minutes)} minutes`;
+            } else {
+                return `${Math.round(hours)} hours`;
+            }
+        } else if (seconds > 60) {
+            return `${Math.round(seconds / 60)} minutes`;
         } else {
-            return `${Math.round(hours)} hours`;
+            return `${Math.round(seconds)} seconds`;
         }
-    } else if (seconds > 60) {
-        return `${Math.round(seconds / 60)} minutes`;
-    } else {
-        return `${Math.round(seconds)} seconds`;
     }
-}
 
-let searchStatsGraph = document.querySelector(".search-stats-graph");
-let searchStatsText = document.querySelector(".search-stats-text");
-let ol = searchStatsText.querySelector("ol");
+    let searchStatsGraph = document.querySelector(".search-stats-graph");
+    let searchStatsText = document.querySelector(".search-stats-text");
+    let ol = searchStatsText.querySelector("ol");
 
-// Generate default type data.
-let defaultTypeData = {};
-Object.keys(STATS_MAP).forEach(name => {
-    defaultTypeData[name] = 0;
-});
-// Merge default type data with statistic type data.
-let array = Object.entries(Object.assign(defaultTypeData, stats.typeData));
-// Split the other part from the others in order to
-// keep the other part always in the last order.
-[
-    ...array.filter(([key, value]) => key !== TYPE_OTHER)
-    .sort((a, b) => b[1] - a[1]),
-    // Other part always the last.
-    ...array.filter(([key, value]) => key === TYPE_OTHER),
-].forEach(([name, value]) => {
-    let { color, description } = STATS_MAP[name];
-    let li = document.createElement("li");
-    let percent = total ? (value / total * 100).toFixed(1): 0.0;
-    li.innerHTML = `<div aria-label="${description}" data-balloon-pos="up" data-balloon-length="large"
+    // Generate default type data.
+    let defaultTypeData = {};
+    Object.keys(STATS_MAP).forEach(name => {
+        defaultTypeData[name] = 0;
+    });
+    // Merge default type data with statistic type data.
+    let array = Object.entries(Object.assign(defaultTypeData, stats.typeData));
+    // Split the other part from the others in order to
+    // keep the other part always in the last order.
+    [
+        ...array.filter(([key, value]) => key !== TYPE_OTHER)
+        .sort((a, b) => b[1] - a[1]),
+        // Other part always the last.
+        ...array.filter(([key, value]) => key === TYPE_OTHER),
+    ].forEach(([name, value]) => {
+        let { color, description } = STATS_MAP[name];
+        let li = document.createElement("li");
+        let percent = total ? (value / total * 100).toFixed(1) : 0.0;
+        li.innerHTML = `<div aria-label="${description}" data-balloon-pos="up" data-balloon-length="large"
                         style="text-align: center" class="tooltip-color">
                         <span class="color-circle-dot" style="background-color:${color}"></span>
                         <span class="">${name}</span>
                         <span class="">${percent}%</span>
                      </div>`;
-    ol.append(li);
-    if (value > 0) {
-        searchStatsGraph.insertAdjacentHTML('beforeend',
-            `<span class="percent-bar" style="width: ${percent}%; background-color:${color}"></span>`
-        );
-    }
-});
+        ol.append(li);
+        if (value > 0) {
+            searchStatsGraph.insertAdjacentHTML('beforeend',
+                `<span class="percent-bar" style="width: ${percent}%; background-color:${color}"></span>`
+            );
+        }
+    });
 
-barChart({
-    margin: ({ top: 30, right: 0, bottom: 10, left: 30 }),
-    // Calculate height dynamically to keep the bar with consistence width regardless of the topCratesData length.
-    height: 800 / 15 * topCratesData.length + 40,
-    barHeight: 25,
-    width: 460,
-    data: topCratesData,
-    selector: ".topCratesData",
-    color: CHART_COLOR,
-});
+    barChart({
+        margin: ({ top: 30, right: 0, bottom: 10, left: 30 }),
+        // Calculate height dynamically to keep the bar with consistence width regardless of the topCratesData length.
+        height: 800 / 15 * topCratesData.length + 40,
+        barHeight: 25,
+        width: 460,
+        data: topCratesData,
+        selector: ".topCratesData",
+        color: CHART_COLOR,
+    });
+})();

--- a/manage/templates/js/settings.js
+++ b/manage/templates/js/settings.js
@@ -1,17 +1,17 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
     const autoUpdateCheckbox = document.getElementById('auto-update');
-    autoUpdateCheckbox.checked = settings.autoUpdate;
-    autoUpdateCheckbox.onchange = function(event) {
+    autoUpdateCheckbox.checked = await settings.autoUpdate;
+    autoUpdateCheckbox.onchange = async function(event) {
         settings.autoUpdate = event.target.checked;
     };
 
     // Offline mode checkbox
-    if (!settings.offlineDocPath) {
+    if (!(await settings.offlineDocPath)) {
         // If the offline doc path not exists, turn off the offline mode.
         settings.isOfflineMode = false;
     }
     const offlineModeCheckbox = document.getElementById('offline-mode');
-    const checkedState = settings.isOfflineMode;
+    const checkedState = await settings.isOfflineMode;
     offlineModeCheckbox.checked = checkedState;
     toggleOfflinePathEnableState(checkedState);
     offlineModeCheckbox.onchange = function(event) {
@@ -22,18 +22,18 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Offline doc path
     const offlineDocPath = document.querySelector('.offline-doc-path');
-    offlineDocPath.value = settings.offlineDocPath;
+    offlineDocPath.value = await settings.offlineDocPath;
     offlineDocPath.onchange = function(event) {
         settings.offlineDocPath = event.target.value;
     };
 
     let crateRegistry = document.querySelector("select[name='crate-registry']");
-    crateRegistry.value = settings.crateRegistry;
+    crateRegistry.value = await settings.crateRegistry;
     crateRegistry.onchange = function() {
         settings.crateRegistry = crateRegistry.value;
     };
 
-    setupDefaultSearch();
+    await setupDefaultSearch();
 }, false);
 
 
@@ -48,12 +48,12 @@ function toggleOfflinePathEnableState(enable) {
     }
 }
 
-function setupDefaultSearch() {
+async function setupDefaultSearch() {
     const thirdPartyDocs = document.getElementById('ds-3rd-docs');
     const docsRs = document.getElementById('ds-docs-rs');
     const attributes = document.getElementById('ds-attributes');
 
-    let defaultSearch = settings.defaultSearch;
+    let defaultSearch = await settings.defaultSearch;
 
     thirdPartyDocs.checked = defaultSearch.thirdPartyDocs;
     docsRs.checked = defaultSearch.docsRs;

--- a/manage/templates/settings.html
+++ b/manage/templates/settings.html
@@ -118,7 +118,5 @@
 {% endblock %}
 
 {% block js %}
-<script src="../core/compat.js"></script>
-<script src="../settings.js"></script>
 <script src="./js/settings.js"></script>
 {% endblock %}

--- a/manifest.jsonnet
+++ b/manifest.jsonnet
@@ -13,9 +13,9 @@ local json = manifest.new(
   description='Rust Search Extension - the ultimate search extension for Rust',
 )
              .addIcons(icons())
-             .addPermissions(['storage'])
+             .addPermissions(['storage', 'unlimitedStorage'])
              .addWebAccessibleResources(utils.js_files('script', ['lib', 'add-search-index']))
-             .addBackgroundScripts(['settings.js', 'deminifier.js'])
+             .addBackgroundScripts(['migration.js', 'settings.js', 'deminifier.js', 'core/storage.js'])
              .addBackgroundScripts(utils.js_files('search', ['algorithm', 'book', 'crate', 'attribute', 'caniuse', 'lint']))
              .addBackgroundScripts(utils.js_files('search/docs', ['base', 'std', 'crate-doc', 'rustc']))
              .addBackgroundScripts(utils.js_files('index', ['attributes', 'books', 'caniuse', 'crates', 'std-docs', 'lints', 'labels', 'rfcs', 'commands']))


### PR DESCRIPTION
This migration is required because Chrome Manifest V3 changes the background script to the service worker,
however, the service worker doesn't support localStorage API. Therefore, we should migrate those data to
chrome.storage before we upgrade to Manifest V3. Otherwise, we can't do such a migration, because we
cannot access localStorage API in the service worker anymore.