### PR TITLE
Distinguish crateName with libName

### DIFF
--- a/extension/crate-manager.js
+++ b/extension/crate-manager.js
@@ -3,20 +3,53 @@ class CrateDocManager {
         return await storage.getItem("crates") || {};
     }
 
-    static async getCrateSearchIndex(name) {
-        return await storage.getItem(`@${name}`);
+    // The `name` cloud be crateName or libName.
+    static async getCrateByName(name) {
+        let crates = await CrateDocManager.getCrates();
+        if (crates[name]) {
+            return crates[name];
+        } else {
+            let crate = Object.entries(crates).find(([_, { crateName }]) => crateName == name);
+            if (crate) {
+                return crate[1];
+            } else {
+                return null;
+            }
+        }
     }
 
-    static async addCrate(name, version, searchIndex) {
-        if (name in searchIndex) {
-            await storage.setItem(`@${name}`, searchIndex);
-            let doc = searchIndex[name]["doc"];
+    // The `name` cloud be crateName or libName.
+    static async getCrateSearchIndex(name) {
+        let searchIndex = await storage.getItem(`@${name}`);
+        if (searchIndex) {
+            return searchIndex;
+        } else {
             let crates = await CrateDocManager.getCrates();
-            if (name in crates) {
-                // Don't override the time if the crate exists
-                crates[name] = {version, doc, time: crates[name].time};
+            let crate = Object.entries(crates).find(([_, { crateName }]) => crateName == name);
+            if (crate) {
+                let libName = crate[0];
+                return await storage.getItem(`@${libName}`);
             } else {
-                crates[name] = {version, doc, time: Date.now()};
+                return null;
+            }
+        }
+    }
+
+    // Some corner cases the crateName different to libName:
+    // 1. https://docs.rs/actix-web/3.2.0/actix_web/
+    // 2. https://docs.rs/md-5/0.10.5/md5/
+    // 
+    // Here is the rule: https://docs.rs/{crateName}/{crateVersion}/{libName}
+    static async addCrate(libName, version, searchIndex, crateName) {
+        if (libName in searchIndex) {
+            await storage.setItem(`@${libName}`, searchIndex);
+            let doc = searchIndex[libName]["doc"];
+            let crates = await CrateDocManager.getCrates();
+            if (libName in crates) {
+                // Don't override the time if the crate exists
+                crates[libName] = { version, doc, time: crates[libName].time, crateName };
+            } else {
+                crates[libName] = { version, doc, time: Date.now(), crateName };
             }
             await storage.setItem("crates", crates);
         }

--- a/extension/main.js
+++ b/extension/main.js
@@ -134,9 +134,9 @@ function getPlatformOs() {
             } else if (content && /^https?.*\/~\/\*\/.*/ig.test(content)) {
                 // Sanitize docs url which from all crates doc search mode. (Prefix with "~")
                 // Here is the url instance: https://docs.rs/~/*/reqwest/fn.get.html
-                let [_, __, crateName] = new URL(content).pathname.slice(1).split("/");
-                let crateVersion = (await CrateDocManager.getCrates())[crateName].version;
-                return content.replace("/~/", `/${crateName}/`).replace("/*/", `/${crateVersion}/`);
+                let [_, __, libName] = new URL(content).pathname.slice(1).split("/");
+                let crate = await CrateDocManager.getCrateByName(libName);
+                return content.replace("/~/", `/${crate.crateName || libName}/`).replace("/*/", `/${crate.version}/`);
             } else {
                 return content;
             }

--- a/extension/manage/js/crates.js
+++ b/extension/manage/js/crates.js
@@ -18,10 +18,10 @@ function buildCrateItem(crate) {
     li.style.padding = "15px";
     li.innerHTML = `<div style="display: flex; flex-direction: column;">
         <div>
-            <b class="subtitle-text">${crate.name}</b>
+            <b class="subtitle-text">${crate.crateName || crate.name}</b>
             <span class="crate-attr">v${crate.version}</span>
-            <a class="crate-attr" href="https://crates.io/crates/${crate.name}" target="_blank">crates.io</a>
-            <a class="crate-attr" href="https://docs.rs/${crate.name}" target="_blank">docs.rs</a>
+            <a class="crate-attr" href="https://crates.io/crates/${crate.crateName || crate.name}" target="_blank">crates.io</a>
+            <a class="crate-attr" href="https://docs.rs/${crate.crateName || crate.name}" target="_blank">docs.rs</a>
         </div>
         <div class="crate-desc">${crate.doc}</div>
         <div class="crate-extra subtext">

--- a/extension/script/add-search-index.js
+++ b/extension/script/add-search-index.js
@@ -2,7 +2,7 @@
     function sendSearchIndex() {
         if (location.hostname === "docs.rs") { // docs.rs pages
             // Parse crate info from location pathname.
-            let [_, crateVersion, crateName] = location.pathname.slice(1).split("/");
+            let [crateName, crateVersion, libName] = location.pathname.slice(1).split("/");
             // Since this PR (https://github.com/rust-lang/docs.rs/pull/1527) merged, 
             // the latest version path has changed:
             // from https://docs.rs/tokio/1.14.0/tokio/ to https://docs.rs/tokio/latest/tokio/
@@ -15,6 +15,7 @@
             window.postMessage({
                 direction: "rust-search-extension:docs.rs",
                 message: {
+                    libName,
                     crateName,
                     crateVersion,
                     searchIndex: window.searchIndex,

--- a/extension/search/docs/crate-doc.js
+++ b/extension/search/docs/crate-doc.js
@@ -17,8 +17,8 @@ class CrateDocSearch {
 
     async initAllCrateSearcher() {
         let searchIndex = Object.create(null)
-        for (const crateName of Object.keys(await CrateDocManager.getCrates())) {
-            searchIndex = Object.assign(searchIndex, await CrateDocManager.getCrateSearchIndex(crateName));
+        for (const libName of Object.keys(await CrateDocManager.getCrates())) {
+            searchIndex = Object.assign(searchIndex, await CrateDocManager.getCrateSearchIndex(libName));
         }
         this.allCrateSearcher = new SingleCrateDocSearch("~", "*", searchIndex);
     }
@@ -32,16 +32,16 @@ class CrateDocSearch {
         if (this.cachedCrateSearcher?.name === crateName) {
             searcher = this.cachedCrateSearcher;
         } else {
-            let crates = await CrateDocManager.getCrates();
-            let crate = crates[crateName];
+            let crate = await CrateDocManager.getCrateByName(crateName);
             if (crate) {
                 let searchIndex = await CrateDocManager.getCrateSearchIndex(crateName);
                 searcher = new SingleCrateDocSearch(crateName, crate.version, searchIndex);
 
                 this.cachedCrateSearcher = searcher;
             } else {
-                let list = Object.entries(crates).map(([name, crate]) => {
-                    crate["name"] = name;
+                let crates = await CrateDocManager.getCrates();
+                let list = Object.entries(crates).map(([libName, crate]) => {
+                    crate["name"] = crate.crateName || libName;
                     return crate;
                 });
 
@@ -54,7 +54,7 @@ class CrateDocSearch {
                     });
                 } else {
                     list.unshift({
-                        content: `https://docs.rs/${crateName}/?search=${encodeURIComponent(keyword)}`,
+                        content: `https://docs.rs/${crateName}/latest/?search=${encodeURIComponent(keyword)}`,
                         description: `Crate ${c.match(crateName)} has not been indexed, search ${keyword ? c.match(keyword) : 'keyword'} on ${c.dim(`https://docs.rs/${crateName}`)} directly`,
                     });
                 }


### PR DESCRIPTION
Some corner cases the `crateName` is different to `libName`:
1. https://docs.rs/actix-web/3.2.0/actix_web/
2. https://docs.rs/md-5/0.10.5/md5/

The rule is: `https://docs.rs/{crateName}/{crateVersion}/{libName}`

Related issue: #216 