### PR TITLE
Fix cargo book command

### DIFF
--- a/extension/index/commands.js
+++ b/extension/index/commands.js
@@ -3,7 +3,7 @@ var commandsIndex = {
         ["The Rust Programming Language", "https://doc.rust-lang.org/stable/book/"],
         ["Rust Async Book", "https://rust-lang.github.io/async-book/"],
         ["Rust Edition Guide Book", "https://doc.rust-lang.org/stable/edition-guide/"],
-        ["The Cargo Book", "https://doc.rust-lang.org/cargo/index.html"],
+        ["The Cargo Book", "https://doc.rust-lang.org/cargo/"],
         ["Rust and WebAssembly Book", "https://rustwasm.github.io/docs/book/"],
         ["Wasm-Pack Book", "https://rustwasm.github.io/docs/wasm-pack/"],
         ["The Embedded Rust Book", "https://rust-embedded.github.io/book/"],


### PR DESCRIPTION
This commit removes the redundant `index.html` in the `cargo book` link, which solves the incorrect link formation such as `https://doc.rust-lang.org/cargo/index.htmlreference/workspaces.html`