### PR TITLE
Fix offline mode not working in Chrome

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -90,7 +90,7 @@ path is your doc directory.
 
 - For Chrome/Edge users:
   Prepend `file://` before your doc directory, and input it to the input box on the
-  settings page.
+  settings page. Then [enable access to file URLs](https://developer.chrome.com/docs/extensions/develop/concepts/declare-permissions#allow_access_to_file_urls_and_incognito_pages) on the extension's details page.
 
   ![GIF](/offline-mode-chrome.gif)
 

--- a/manifest.jsonnet
+++ b/manifest.jsonnet
@@ -15,6 +15,7 @@ local description = 'Rust Search Extension - the ultimate search extension for R
 local browser = std.extVar('browser');
 
 local host_permissions = ['*://crates.io/api/v1/crates/*', 'https://rust.extension.sh/*'];
+local optional_host_permissions = ['file:///*'];
 local json = if std.member(['chrome', 'edge'], browser) then
   local manifest_v3 = import 'core/manifest_v3.libsonnet';
   manifest_v3.new(name, keyword, description, version, service_worker='service-worker.js')
@@ -33,6 +34,7 @@ local json = if std.member(['chrome', 'edge'], browser) then
     [if browser == 'chrome' then 'key' else null]: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxOX+QfzcFnxPwwmzXDhuU59XGCSMZq+FGo0vOx/ufg/Vw7HfKEPVb9TKzrGtqW38kafWkjxOxGhF7VyyX2ymi55W0xqf8BedePbvMtV6H1tY5bscJ0dLKGH/ZG4T4f645LgvOWOBgyv8s3NDWXzwOMS57ER1y+EtHjDsWD1M0nfe0VCCLW18QlAsNTHfLZk6lUeEeGXZrl6+jK+pZxwhQFmc8cJvOyw7uAq6IJ9lnGDvxFVjGUepA0lKbLuIZjN3p70mgVUIuBYzKE6R8HDk4oBbKAK0HyyKfnuAYbfwVYotHw4def+OW9uADSlZEDC10wwIpU9NoP3szh+vWSnk0QIDAQAB',
   }
   .addHostPermissions(host_permissions)
+  .addOptionalHostPermissions(optional_host_permissions)
 else
   local manifest_v2 = import 'core/manifest.libsonnet';
   manifest_v2.new(name, keyword, description, version)


### PR DESCRIPTION
Closes #263 by making the "Allow access to file URLs" setting show. Tested to work in Chrome 123.0.6312.58.

This PR relies on huhu/search-extension-core#12 to be merged first and requires an update of the `core` submodule afterwards. Thank you for your attention.

Edit: I tried to test this on Edge but I wasn't allowed to enable the extension for security reasons. However, the "Allow access to file URLs" setting did show, so I guess it would work similarly.