### PR TITLE
Fix search of extern crates

### DIFF
--- a/extension/search/docs/base.js
+++ b/extension/search/docs/base.js
@@ -81,7 +81,7 @@ class DocSearch {
             searchWords.push(crateName);
             searchIndex.push({
                 crate: crateName,
-                ty: 1, // == ExternCrate
+                ty: 3, // == ExternCrate
                 name: crateName,
                 path: "",
                 desc: indexItem.doc,


### PR DESCRIPTION
At this moment, search results for extern crates such as `std`, `test`, and `proc_macro` lead to wrong places because their types are incorrectly set to `primitive`. This PR fixes the bug.