### PR TITLE
Fix docs.rs TOC if headings contain inline code

### DIFF
--- a/extension/script/docs-rs.js
+++ b/extension/script/docs-rs.js
@@ -65,19 +65,8 @@ document.addEventListener("DOMContentLoaded", () => {
     let ul = document.createElement("ul");
     ul.classList.add("rse-doc-toc");
     for (let header of headers) {
-        let href, textContent;
-        // The header may contain a link or not.
-        // See also https://github.com/huhu/rust-search-extension/pull/268
-        if (header.childNodes.length > 1) {
-            let [link, text] = header.childNodes;
-            href = link.href;
-            textContent = text.nodeValue;
-        } else {
-            let link = header.firstChild;
-            href = link.href;
-            textContent = link.textContent;
-        }
-
+        let href = header.firstChild.href;
+        let textContent = header.innerText;
         let item = document.createElement("li");
         item.innerHTML = `<div class="rse-doc-toc-item rse-doc-toc-${header.tagName.toLowerCase()}">
                 <a href="${href}">${textContent}</a>


### PR DESCRIPTION
Example: https://docs.rs/tokio/latest/tokio/sync/index.html

Headings that contain inline code have more than two child nodes since each inline code and text between them is a separate child, so only taking the node value from the second child does not provide the full heading. Worse, if the heading starts with a code tag, the heading will currently be "null" (since `nodeValue` only works on text nodes).

`header.innerText` instead gets the complete rendered text of the whole heading across all children.