### PR TITLE
Always run initialization code on browser start

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -114,6 +114,9 @@ async function start(omnibox) {
 
     if (!omnibox.extensionMode) return;
 
+    // NOTE: this kind of async registration is specifically discouraged in manifest v2
+    // not sure if it works properly in v3? https://developer.chrome.com/docs/extensions/mv2/background-pages#listeners
+    // See also https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#register-listeners
     chrome.storage.onChanged.addListener(async changes => {
         for (let [key, { oldValue, newValue }] of Object.entries(changes)) {
             console.log('storage key updated:', key);

--- a/extension/service-worker.js
+++ b/extension/service-worker.js
@@ -50,9 +50,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
 });
 
-(async () => {
+async function init() {
     const defaultSuggestion = `Search std <match>docs</match>, external <match>docs</match> (~,@), <match>crates</match> (!), <match>attributes</match> (#), <match>books</match> (%), clippy <match>lints</match> (>), and <match>error codes</match>, etc in your address bar instantly!`;
     const omnibox = Omnibox.extension({ defaultSuggestion, maxSuggestionSize: Compat.omniboxPageSize() });
     await start(omnibox);
     await checkAutoUpdate();
-})();
+}
+
+chrome.runtime.onStartup.addListener(init);
+chrome.runtime.onInstalled.addListener(init);


### PR DESCRIPTION
This *might* fix or at least help with #229, #182 

This seems to work more consistently than the existing code in Firefox. Particularly, I could generally reproduce the extension not working (v2.0.0) if I simply quit and restart Firefox Dev multiple times.

With this change, the extension loads on every browser startup, which seems like the desired behavior, and also should be reinitialized on upgrades.

It might also be worth considering using this `background.scripts` manifest instead of a custom page, but that would require changes to `core/manifest_v3.libsonnet` and doesn't seem to be necessary for these changes to help.