### PR TITLE
Firefox: use alarms to keep service worker running

### DIFF
--- a/extension/firefox-bg.html
+++ b/extension/firefox-bg.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <title>Rust Search Extension</title>
         <script src="service-worker.js" type="module"></script>
+        <script src="service-worker-keepalive.js" type="module"></script>
   </head>
   <body></body>
 </html>

--- a/extension/service-worker-keepalive.js
+++ b/extension/service-worker-keepalive.js
@@ -1,0 +1,16 @@
+/**
+ * This is a hack to keep the service worker running forever on Firefox, which
+ * aggressively shuts down the worker on Manifest v3 (resulting in a poor search experience).
+ *
+ * It may be possible to fine-tune the event registration so this isn't necessary,
+ * but it seems like even re-initializing for omnibox.onInputStarted isn't enough to
+ * get suggestions working how they used to in manifest v2.
+ *
+ * See <https://bugzilla.mozilla.org/show_bug.cgi?id=1771203> for more info.
+ **/
+browser.alarms.onAlarm.addListener(() => {
+    // This handler doesn't need to do anything, merely exist.
+});
+
+// Default idle timeout is 30s, this alarm will fire every 20s
+browser.alarms.create("keepalive", { periodInMinutes: 1.0 / 3.0 });

--- a/manifest.jsonnet
+++ b/manifest.jsonnet
@@ -46,7 +46,7 @@ json
 .addHostPermissions(host_permissions)
 .addOptionalHostPermissions(optional_host_permissions)
 .addIcons(icons())
-.addPermissions(['storage', 'unlimitedStorage'])
+.addPermissions(['storage', 'unlimitedStorage', 'alarms'])
 .setOptionsUi('manage/index.html')
 .addContentScript(
   matches=['*://docs.rs/*'],


### PR DESCRIPTION
Closes #229, #182 
Second try, I *think* for real this time.

This is a follow-up to #295, which doesn't seem to be enough to guarantee a good search experience the first time typing.

It's a bit of a hack, but it simply sets an alarm in the background which keeps the service worker running indefinitely. This alarm approach seems to be not recommended, but it works well enough and can be limited to just run on Firefox where it's an issue.

Without a much larger refactor or extensive testing, I think this is truly the best short term solution to using the extension on Firefox!