### PR TITLE
docs: add browser packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ $ make firefox # For Firefox version
 $ make edge # For Edge version
 ```
 
+## Build Instructions
+
+To build packages for different browsers, use the `make pack` command followed by the target browser name.
+
+### Syntax
+
+```bash
+make pack chrome
+
+make pack firefox
+
+make pack edge
+```
+
 ## Get involved
 
 You can contact us on Discord Channel: https://discord.gg/xucZNVd


### PR DESCRIPTION
I'm not able to create a package which can be loaded in the browser without pack.

<img width="1195" height="250" alt="Screenshot 2025-10-24 at 9 08 11 AM" src="https://github.com/user-attachments/assets/5b5ba128-970c-4f93-b56c-1d56bc429880" />
