### PR TITLE
feat(ci): nightly build

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -104,6 +104,14 @@ jobs:
           draft: false
           prerelease: true
 
+      - name: Find built packages
+        if: github.event_name != 'pull_request'
+        id: find_packages
+        run: |
+          echo "chrome_package=$(ls web-ext-artifacts/chrome-rust-search-extension-*.zip)" >> $GITHUB_OUTPUT
+          echo "firefox_package=$(ls web-ext-artifacts/firefox-rust-search-extension-*.zip)" >> $GITHUB_OUTPUT
+          echo "edge_package=$(ls web-ext-artifacts/edge-rust-search-extension-*.zip)" >> $GITHUB_OUTPUT
+
       - name: Upload Chrome Release Asset
         if: github.event_name != 'pull_request'
         uses: actions/upload-release-asset@v1
@@ -111,7 +119,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./web-ext-artifacts/chrome-rust-search-extension-*.zip
+          asset_path: ${{ steps.find_packages.outputs.chrome_package }}
           asset_name: chrome-rust-search-extension-nightly-${{ steps.date.outputs.date }}.zip
           asset_content_type: application/zip
 
@@ -122,7 +130,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./web-ext-artifacts/firefox-rust-search-extension-*.zip
+          asset_path: ${{ steps.find_packages.outputs.firefox_package }}
           asset_name: firefox-rust-search-extension-nightly-${{ steps.date.outputs.date }}.zip
           asset_content_type: application/zip
 
@@ -133,7 +141,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./web-ext-artifacts/edge-rust-search-extension-*.zip
+          asset_path: ${{ steps.find_packages.outputs.edge_package }}
           asset_name: edge-rust-search-extension-nightly-${{ steps.date.outputs.date }}.zip
           asset_content_type: application/zip
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -5,6 +5,10 @@ on:
     # Run at 00:00 UTC every day
     - cron: '0 0 * * *'
   workflow_dispatch: # Allow manual triggering
+  pull_request:
+    branches:
+      - main
+      - master
 
 jobs:
   build:
@@ -51,15 +55,26 @@ jobs:
       - name: Build Edge package
         run: make pack edge
 
+      - name: Upload build artifacts (PR only)
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-packages
+          path: web-ext-artifacts/*.zip
+          retention-days: 7
+
       - name: Get current date
+        if: github.event_name != 'pull_request'
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Get short commit SHA
+        if: github.event_name != 'pull_request'
         id: sha
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Create Release
+        if: github.event_name != 'pull_request'
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -90,6 +105,7 @@ jobs:
           prerelease: true
 
       - name: Upload Chrome Release Asset
+        if: github.event_name != 'pull_request'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -100,6 +116,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload Firefox Release Asset
+        if: github.event_name != 'pull_request'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,6 +127,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload Edge Release Asset
+        if: github.event_name != 'pull_request'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -120,6 +138,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Clean up old nightly releases
+        if: github.event_name != 'pull_request'
         uses: dev-drprasad/delete-older-releases@v0.3.2
         with:
           keep_latest: 7

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -149,7 +149,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: dev-drprasad/delete-older-releases@v0.3.2
         with:
-          keep_latest: 7
+          keep_latest: 1
           delete_tag_pattern: nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,128 @@
+name: Nightly Release
+
+on:
+  schedule:
+    # Run at 00:00 UTC every day
+    - cron: '0 0 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  build:
+    name: Build Nightly Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install jsonnet
+        run: |
+          wget https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Linux_x86_64.tar.gz
+          tar -xzf go-jsonnet_0.20.0_Linux_x86_64.tar.gz
+          sudo mv jsonnet /usr/local/bin/
+          sudo chmod +x /usr/local/bin/jsonnet
+          jsonnet --version
+
+      - name: Install Node.js dependencies
+        run: |
+          npm install -g esbuild web-ext
+
+      - name: Build Chrome package
+        run: make pack chrome
+
+      - name: Build Firefox package
+        run: make pack firefox
+
+      - name: Build Edge package
+        run: make pack edge
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Get short commit SHA
+        id: sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly-${{ steps.date.outputs.date }}-${{ steps.sha.outputs.sha }}
+          release_name: Nightly Release ${{ steps.date.outputs.date }}
+          body: |
+            Automated nightly build from commit ${{ github.sha }}
+
+            ## Installation
+
+            ### Chrome/Edge
+            1. Download the Chrome or Edge package
+            2. Extract the zip file
+            3. Open chrome://extensions/ (or edge://extensions/)
+            4. Enable "Developer mode"
+            5. Click "Load unpacked" and select the extracted folder
+
+            ### Firefox
+            1. Download the Firefox package
+            2. Open about:debugging#/runtime/this-firefox
+            3. Click "Load Temporary Add-on"
+            4. Select the downloaded .zip file
+
+            **Note:** This is a nightly build and may contain experimental features or bugs.
+          draft: false
+          prerelease: true
+
+      - name: Upload Chrome Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./web-ext-artifacts/chrome-rust-search-extension-*.zip
+          asset_name: chrome-rust-search-extension-nightly-${{ steps.date.outputs.date }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload Firefox Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./web-ext-artifacts/firefox-rust-search-extension-*.zip
+          asset_name: firefox-rust-search-extension-nightly-${{ steps.date.outputs.date }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload Edge Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./web-ext-artifacts/edge-rust-search-extension-*.zip
+          asset_name: edge-rust-search-extension-nightly-${{ steps.date.outputs.date }}.zip
+          asset_content_type: application/zip
+
+      - name: Clean up old nightly releases
+        uses: dev-drprasad/delete-older-releases@v0.3.2
+        with:
+          keep_latest: 7
+          delete_tag_pattern: nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -55,13 +55,16 @@ Input keyword **rs** in the address bar, press `Space` to activate the search ba
 
 ## Contribution
 
-[jsonnet](https://jsonnet.org/) is required before getting started. To install `jsonnet`, please check `jsonnet`'s [README](https://github.com/google/jsonnet#packages).
-For Linux users, the `snap` is a good choice to [install jsonnet](https://snapcraft.io/install/jsonnet/ubuntu).
+[jsonnet](https://jsonnet.org/) is required before getting started. To install `jsonnet`, please check `jsonnet`'s [README](https://github.com/google/go-jsonnet).
 
 ```bash
+# install jsonnet
+
 $ git clone --recursive https://github.com/huhu/rust-search-extension
 Cloning into 'rust-search-extension'...
 $ cd rust-search-extension
+
+$ npm install -g esbuild web-ext
 
 $ make chrome # For Chrome version
 


### PR DESCRIPTION
For PR, a build is triggered
For cronjob and manual trigger, it will also create pre-release

In this way one can download bundle extensions from both PR and nightly release

Demo run https://github.com/yujqiao/rust-search-extension/actions

Release fixes for https://github.com/huhu/rust-search-extension/issues/182 https://github.com/huhu/rust-search-extension/issues/301